### PR TITLE
Fix hallucination desync

### DIFF
--- a/libnitrohack/include/decl.h
+++ b/libnitrohack/include/decl.h
@@ -123,6 +123,7 @@ extern struct sinfo {
 	int exiting;		/* an exit handler is executing */
 #endif
 	int in_impossible;
+	int in_zero_time_command;
 #ifdef PANICLOG
 	int in_paniclog;
 #endif

--- a/libnitrohack/include/display.h
+++ b/libnitrohack/include/display.h
@@ -136,6 +136,9 @@
 #define canseeself()	(Blind || u.uswallow || (!Invisible && !u.uundetected))
 #define senseself()	(canseeself() || Unblind_telepat || Detect_monsters)
 
+#define newsym_rng(x)                                                   \
+  (program_state.in_zero_time_command ? display_rng(x) : rn2(x))
+
 /*
  * random_monster()
  * random_object()
@@ -143,9 +146,9 @@
  *
  * Respectively return a random monster, object, or trap number.
  */
-#define random_monster() (display_rng(NUMMONS))
-#define random_object()  (display_rng(NUM_OBJECTS-1) + 1)
-#define random_trap()	 (display_rng(TRAPNUM-1) + 1)
+#define random_monster() (newsym_rng(NUMMONS))
+#define random_object()  (newsym_rng(NUM_OBJECTS-1) + 1)
+#define random_trap()	 (newsym_rng(TRAPNUM-1) + 1)
 
 /*
  * what_obj()

--- a/libnitrohack/src/cmd.c
+++ b/libnitrohack/src/cmd.c
@@ -1835,6 +1835,16 @@ int do_command(int command, int repcount, boolean firsttime, struct nh_cmd_arg *
 	    repcount = prev_repcount;
 	}
 	
+	if (command >= 0 && (cmdlist[command].flags & CMD_NOTIME))
+	    program_state.in_zero_time_command = TRUE;
+	else
+	    program_state.in_zero_time_command = FALSE;
+
+	/* if we're hallucinating, make sure to flush screen data when not in
+	   zero-time, or we'll possibly end up saving display rng data */
+	if (!program_state.in_zero_time_command && Hallucination)
+	    vision_recalc(0);
+
 	/* NULL arg is synonymous to CMD_ARG_NONE */
 	if (!arg)
 	    arg = &noarg;

--- a/nitrohack/src/replay.c
+++ b/nitrohack/src/replay.c
@@ -226,9 +226,29 @@ void replay_commandloop(int fd)
 		}
 		break;
 		
+	    /* step forward 50 turns */
+	    case KEY_NPAGE:
+		ret = nh_view_replay_step(&rinfo, REPLAY_FORWARD,
+		                          min(50, max(1, rinfo.max_actions - rinfo.actions)));
+		draw_replay_info(&rinfo);
+		if (ret == FALSE) {
+		    key = curses_msgwin("You have reached the end of this game. "
+		                        "Go back or press ESC to exit.");
+		    if (key == KEY_ESC)
+			goto out;
+		}
+		break;
+		
 	    /* step backward */
 	    case KEY_LEFT:
 		nh_view_replay_step(&rinfo, REPLAY_BACKWARD, 1);
+		draw_replay_info(&rinfo);
+		break;
+		
+	    /* step backward 50 turns */
+	    case KEY_PPAGE:
+		nh_view_replay_step(&rinfo, REPLAY_BACKWARD,
+                                    min(50, max(1, rinfo.actions - 1)));
 		draw_replay_info(&rinfo);
 		break;
 		


### PR DESCRIPTION
This PR does NOT address the save problems encountered during debugging, because I've yet to devise a fix to it that is more than just a hack, atm (want to see if it truly solves everything first before I try to fix it properly).

Well, this is one case where the game will 100% desync. Hallucination used the display RNG (a RNG that doesn't change the normal game RNG's output, so it can redraw stuff when hallucinating) instead of the regular one, but when randomizing objects or traps, the results of the RNG calls can end up being saved in the save. This is a problem if the player, for example, farlooked something when hallucinating.

This will change it so that Hallucinating will call the regular RNG whenever the player does something that should affect the underlying gamestate, and will also flush the display to make sure the data is actually used in all cases.